### PR TITLE
feat: add basic scheduling engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ For complete technical specifications, user stories, acceptance criteria, and im
 
 ## Getting Started
 
-*Coming soon - Development roadmap and setup instructions will be added as the project progresses.*
+To run the sample scheduling engine tests:
+
+```bash
+npm test
+```
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "project-estimation-timeline-app",
+  "version": "1.0.0",
+  "description": "A bilingual (ID/EN) project estimation and scheduling app for Indonesian project managers, featuring accurate timelines, overtime projections, compliance with Indonesian labor regulations, and clear stakeholder communication.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test/scheduler.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,0 +1,53 @@
+const WEEKEND = [0,6];
+
+function nextWorkingDay(date){
+  const d = new Date(date);
+  while (WEEKEND.includes(d.getDay())) {
+    d.setDate(d.getDate()+1);
+  }
+  return d;
+}
+
+function addWorkingDays(startDate, days){
+  let d = new Date(startDate);
+  while (days > 0){
+    d.setDate(d.getDate()+1);
+    if (!WEEKEND.includes(d.getDay())){
+      days--;
+    }
+  }
+  return d;
+}
+
+function scheduleTasks(tasks, startDate, hoursPerDay=8){
+  const unscheduled = new Map();
+  tasks.forEach(t => unscheduled.set(t.id, t));
+  const scheduled = {};
+  const start = nextWorkingDay(new Date(startDate));
+
+  while (unscheduled.size){
+    let progress = false;
+    for (const [id, task] of Array.from(unscheduled.entries())){
+      const deps = task.dependencies || [];
+      const ready = deps.every(dep => scheduled[dep]);
+      if (!ready) continue;
+      let taskStart = new Date(start);
+      for (const dep of deps){
+        const depEnd = scheduled[dep].end;
+        const next = addWorkingDays(depEnd,1);
+        if (next > taskStart) taskStart = next;
+      }
+      taskStart = nextWorkingDay(taskStart);
+      const days = Math.ceil(task.hours / hoursPerDay);
+      const taskEnd = addWorkingDays(taskStart, days-1);
+      scheduled[id] = { ...task, start: taskStart, end: taskEnd };
+      unscheduled.delete(id);
+      progress = true;
+    }
+    if (!progress) throw new Error('Circular or unsatisfied dependencies');
+  }
+
+  return scheduled;
+}
+
+module.exports = { scheduleTasks, addWorkingDays, nextWorkingDay };

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const { scheduleTasks } = require('../src/scheduler');
+
+(function testSimpleChain(){
+  const tasks = [
+    { id: 'prod', hours: 16 },
+    { id: 'design', hours: 8, dependencies: ['prod'] },
+    { id: 'eng', hours: 24, dependencies: ['design'] }
+  ];
+  const start = new Date('2023-11-20');
+  const result = scheduleTasks(tasks, start, 8);
+  const prod = result['prod'];
+  const design = result['design'];
+  const eng = result['eng'];
+  assert.strictEqual(prod.start.toDateString(), new Date('2023-11-20').toDateString());
+  assert.strictEqual(prod.end.toDateString(), new Date('2023-11-21').toDateString());
+  assert.strictEqual(design.start.toDateString(), new Date('2023-11-22').toDateString());
+  assert.strictEqual(design.end.toDateString(), new Date('2023-11-22').toDateString());
+  assert.strictEqual(eng.start.toDateString(), new Date('2023-11-23').toDateString());
+  assert.strictEqual(eng.end.toDateString(), new Date('2023-11-27').toDateString());
+})();
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add initial scheduling engine for chaining tasks with dependencies and weekend-aware planning
- document how to run the sample test suite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd035640832e8f02b220d0bb7096